### PR TITLE
Fix error instance name set to always lower case

### DIFF
--- a/create.yaml
+++ b/create.yaml
@@ -49,6 +49,7 @@ resources:
   name_generator:
     type: OS::Heat::RandomString
     properties:
+      sequence: lowercase
       length: 4
   # USERS
   k8s_user:

--- a/master.yaml
+++ b/master.yaml
@@ -29,6 +29,7 @@ resources:
   server_name_post_fix:
     type: OS::Heat::RandomString
     properties:
+      sequence: lowercase
       length: 4
 
   kube_master:

--- a/minion.yaml
+++ b/minion.yaml
@@ -29,6 +29,7 @@ resources:
   server_name_post_fix:
     type: OS::Heat::RandomString
     properties:
+      sequence: lowercase
       length: 4
 
   kube_minion:

--- a/update.yaml
+++ b/update.yaml
@@ -49,6 +49,7 @@ resources:
   name_generator:
     type: OS::Heat::RandomString
     properties:
+      sequence: lowercase
       length: 4
   # USERS
   k8s_user:


### PR DESCRIPTION
On Openstack, Instance name will be use as hostname on the linux machine, when the hostname contain Upper case, the ansible playbook will be error

```
type: OS::Heat::RandomString
    properties:
      length: 4
```

to


```
type: OS::Heat::RandomString
    properties:
      sequence: lowercase
      length: 4
```

Error detail from playbook
```
TASK [kubernetes/preinstall : Stop if bad hostname] ****************************
Friday 29 March 2019  18:21:08 +0000 (0:00:00.231)       0:00:50.115 **********
^[[0;31mfatal: [k8s-neo-worker-DhWh]: FAILED! => {^[[0m
^[[0;31m    "assertion": "inventory_hostname is match(\"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")", ^[[0m
^[[0;31m    "changed": false, ^[[0m
^[[0;31m    "evaluated_to": false, ^[[0m
^[[0;31m    "msg": "Hostname must consist of lower case alphanumeric characters, '.' or '-', and must start and end with an alphanumeric character"^[[0m
^[[0;31m}^[[0m
```